### PR TITLE
Warn user doing CUD without CUD switch.

### DIFF
--- a/DebugSetup.ps1
+++ b/DebugSetup.ps1
@@ -6,11 +6,15 @@ Write-Host "Hello world"
 ##
 
 $db = "test"
-$sql1 = "update table1 set someint = 4321 where pk = '1A9F96AE-54FA-40F9-9069-749F3ACF0CEF';"
-$sql2 = "update table1 set someint = 1234 where pk = '89F21B61-891B-42CD-9BED-84BA4B7EB7D0';"
+#$sql1 = "update table1 set someint = 4321 where pk = '1A9F96AE-54FA-40F9-9069-749F3ACF0CEF';"
+#$sql2 = "UPDATE table1 set someint = 1234 where pk = '89F21B61-891B-42CD-9BED-84BA4B7EB7D0';"
 
-$count = ($sql1,$sql2) | Invoke-SqlServerQuery -Database $db -CUD -Verbose -ExpectedRowCount 3
-Write-Host "Count $count."
+#$count = ($sql1,$sql2) | Invoke-SqlServerQuery -Database $db -Verbose
+#Write-Host "Count $count."
+
+$sql = "select * from table1 where somestring = ' update insert delete UPDATE INSERT DELETE ';"
+$result = $sql | Invoke-SqlServerQuery -Database $db -Verbose
+$result | ft
 
 #$query = "select * from sometable;"
 #$query | Invoke-SqlServerQuery -Database "test" -Verbose

--- a/InvokeQueryBase.cs
+++ b/InvokeQueryBase.cs
@@ -206,7 +206,7 @@ namespace InvokeQuery
 
         private void RunQuery()
         {
-            var regexPattern = @"(?<=^([^']|'[^']*')*)(update|insert|delete|merge)";
+            var regexPattern = @"(?<=^([^']|'[^']*')*)(update |insert |delete |merge )";
             var uhOh = Regex.Match(SqlQuery.Sql.ToLower(), regexPattern, RegexOptions.Multiline | RegexOptions.IgnoreCase).Success;
             var cudWarning = "WARNING! The following query appears to contain an INSERT/UPDATE/DELETE/MERGE operation, but the CUD switch was not used (which is recommended). Are you sure you want to execute this query?";
 

--- a/InvokeQueryBase.cs
+++ b/InvokeQueryBase.cs
@@ -5,6 +5,7 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Management.Automation;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace InvokeQuery
 {
@@ -205,23 +206,31 @@ namespace InvokeQuery
 
         private void RunQuery()
         {
-            if (ShouldProcess("Database server", "Run Query:`" + SqlQuery.Sql + "`"))
+            var regexPattern = @"(?<=^([^']|'[^']*')*)(update|insert|delete|merge)";
+            var uhOh = Regex.Match(SqlQuery.Sql.ToLower(), regexPattern, RegexOptions.Multiline | RegexOptions.IgnoreCase).Success;
+            var cudWarning = "WARNING! The following query appears to contain an INSERT/UPDATE/DELETE/MERGE operation, but the CUD switch was not used (which is recommended). Are you sure you want to execute this query?";
+
+            if (uhOh && !ShouldContinue(SqlQuery.Sql, cudWarning))
             {
-                var command = GetDbCommand();
-                var dataTable = new DataTable();
-                var adapter = ProviderFactory.CreateDataAdapter();
-                adapter.SelectCommand = command;
-                using (adapter)
-                {
-                    adapter.Fill(dataTable);
-                }
-                WriteVerbose("Query returned " + dataTable.Rows.Count + " rows.");
-                WriteObject(GetDataRowArrayFromTable(dataTable));
+                WriteWarning("Not running query!");
+                return;
             }
-            else
+            if (!ShouldProcess("Database server", "Run Query:`" + SqlQuery.Sql + "`"))
             {
-                WriteObject(new DataTable[0]);
+                WriteWarning("Not running query!");
+                return;
             }
+
+            var command = GetDbCommand();
+            var dataTable = new DataTable();
+            var adapter = ProviderFactory.CreateDataAdapter();
+            adapter.SelectCommand = command;
+            using (adapter)
+            {
+                adapter.Fill(dataTable);
+            }
+            WriteVerbose("Query returned " + dataTable.Rows.Count + " rows.");
+            WriteObject(GetDataRowArrayFromTable(dataTable));
         }
 
         private DataRow[] GetDataRowArrayFromTable(DataTable dataTable)


### PR DESCRIPTION
Warn user if they did an UPDATE, INSERT,DELETE, or MERGE operation without the -CUD switch.

This warning cannot be disabled by the force switch. The user must use -CUD to avoid the warning.

If the text is inside quotes, it will not warn.