### PR TITLE
Fix connection bug to PGSQL

### DIFF
--- a/InvokePostgreSqlQuery.cs
+++ b/InvokePostgreSqlQuery.cs
@@ -1,6 +1,6 @@
-﻿using System.Data.Common;
-using System.Management.Automation;
 using Npgsql;
+using System.Data.Common;
+using System.Management.Automation;
 
 namespace InvokeQuery
 {
@@ -10,6 +10,28 @@ namespace InvokeQuery
         protected override DbProviderFactory GetProviderFactory()
         {
             return NpgsqlFactory.Instance;
+        }
+        protected override void ConfigureConnectionString()
+        {
+            if (!string.IsNullOrEmpty(ConnectionString)) return;
+
+            var connString = new NpgsqlConnectionStringBuilder();
+            connString.Host = Server;
+
+            if (!string.IsNullOrEmpty(Database))
+            {
+                connString.Database = Database;
+            }
+            if (Credential != PSCredential.Empty)
+            {
+                connString.Username = Credential.UserName;
+                connString.Password = Credential.Password.ConvertToUnsecureString();
+            }
+            if (ConnectionTimeout > 0)
+            {
+                connString.Timeout = ConnectionTimeout;
+            }
+            ConnectionString = connString.ToString();
         }
     }
 }


### PR DESCRIPTION
When try to connect to PGSQL without custom ConnectionString parameter, you get error: "Keyword not supported: data source."

Made changes according to Npgsql documentation:
    http://www.npgsql.org/doc/connection-string-parameters.html
    http://www.npgsql.org/api/Npgsql.NpgsqlConnectionStringBuilder.html